### PR TITLE
Remove the libcreds dependency

### DIFF
--- a/dsme/Makefile.am
+++ b/dsme/Makefile.am
@@ -40,7 +40,7 @@ dsme_server_SOURCES = dsme-server.c modulebase.c timers.c logging.c oom.c \
                       mainloop.c dsmesock.c dsme-rd-mode.c
 dsme_server_LDFLAGS = $(AM_LDFLAGS) -rdynamic `pkg-config --libs gthread-2.0` -Wl,--as-needed
 dsme_server_CPPFLAGS = $(CPP_GENFLAGS) $(GLIB_CFLAGS) -DDSME_LOG_ENABLE
-dsme_server_LDADD = $(GLIB_LIBS) -ldsme -ldl -lcreds
+dsme_server_LDADD = $(GLIB_LIBS) -ldsme -ldl
 
 #
 # Headers used by all

--- a/dsme/dsmesock.c
+++ b/dsme/dsmesock.c
@@ -38,7 +38,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <fcntl.h>
-#include <sys/creds.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/stat.h>
@@ -127,21 +126,6 @@ fail:
   return -1;
 }
 
-static bool check_client_credentials(int socketfd)
-{
-  bool          success = true;
-/*  creds_value_t value;
-  creds_type_t  type    = creds_str2creds("dsme::DeviceStateControl", &value);*/
-  creds_t       creds   = creds_getpeer(socketfd);
-
-/*  if (!creds_have_p(creds, type, value)) {
-    success = false;
-  }*/
-
-  creds_free(creds);
-  return success;
-}
-
 static gboolean accept_client(GIOChannel*  source,
                               GIOCondition condition,
                               gpointer     p)
@@ -176,15 +160,6 @@ static gboolean accept_client(GIOChannel*  source,
     newconn->ucred.gid = -1;
   }
 
-  if (!check_client_credentials(newfd)) {
-    char* name = endpoint_name_by_pid(newconn->ucred.pid);
-    dsme_log(LOG_CRIT, "DSME: dropping dsmesock client %s, no dsme::DeviceStateControl credential",
-             name);
-    free(name);
-    close_client(newconn);
-    goto out;
-  }
-
   if (!(newconn->channel = g_io_channel_unix_new(newfd)) ||
       !g_io_add_watch(newconn->channel,
                       (G_IO_IN | G_IO_ERR | G_IO_HUP),
@@ -196,7 +171,6 @@ static gboolean accept_client(GIOChannel*  source,
     add_client(newconn);
   }
 
-out:
   return TRUE; /* do not discard the listening channel */
 }
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -3,7 +3,7 @@
 #
 ACLOCAL_AMFLAGS = -I m4
 AM_CFLAGS = $(C_GENFLAGS) $(C_OPTFLAGS) $(DBUS_CFLAGS) $(GLIB_CFLAGS) -DDSME_LOG_ENABLE
-AM_LDFLAGS = -Wl,--as-needed -pthread -rdynamic $(GLIB_LIBS) -ldsme -ldbus-1 -ldbus-glib-1 -lpthread -ldl -ldsme -lcreds
+AM_LDFLAGS = -Wl,--as-needed -pthread -rdynamic $(GLIB_LIBS) -ldsme -ldbus-1 -ldbus-glib-1 -lpthread -ldl -ldsme
 AM_CPPFLAGS = $(CPP_GENFLAGS) $(GLIB_CFLAGS) $(DBUS_CFLAGS)
 TESTS = testmod_alarmtracker \
 	testmod_emergencycalltracker \


### PR DESCRIPTION
This commit removes the libcreds dependency. The reason for the dependency is that in dsme/dsmesock.c we check that the clients accessing DSME over a socket have a credential for access. Since we no longer in fact perform the check, the whole libcreds dependency (and the check) can be removed.
