### PR TITLE
Fix charger tracking if bme is not available on a device

### DIFF
--- a/modules/usbtracker.c
+++ b/modules/usbtracker.c
@@ -81,9 +81,9 @@ static void usb_state_ind(const DsmeDbusMessage* ind)
 	return;
     }
     if (strcmp(state, "USB connected") == 0 && !connected)
-	connected = true;
+        connected = true;
     else if (strcmp(state, "USB disconnected") == 0 && connected)
-	connected = false;
+        connected = false;
 
     send_charger_status(connected);
 


### PR DESCRIPTION
Based on the connection state we decide if a charger is connected or not.
When a USB cable is connected we should be charging (except for error conditions).

Fixes: JB#6580

Signed-off-by: Philippe De Swert philippe.deswert@jollamobile.com
