### PR TITLE
Apply a less strict version check for the spec file

### DIFF
--- a/verify_version.sh
+++ b/verify_version.sh
@@ -2,27 +2,37 @@
 
 # Check that all files that should have the current version agree on it
 
+# The configure.ac is hand-edited, assume it must be sane
 AC_PATH=configure.ac
 AC_VERS=$(sed '/AC_INIT/!d; s/AC_INIT(dsme, \(.*\))/\1/' $AC_PATH)
 
-RPM_PATH=${RPM_SOURCE_DIR:-rpm}/${RPM_PACKAGE_NAME:-dsme}.spec
-RPM_VERS=$(grep '^Version:' $RPM_PATH |sed -e 's/^.*:[[:space:]]*//')
-
-YAML_PATH=rpm/dsme.yaml
-
 RES=0
 
-if [ "$RPM_VERS" != "$AC_VERS" ]; then
-  echo >&2 "$AC_PATH $AC_VERS vs $RPM_PATH $RPM_VERS"
-  RES=1
+# The .spec is either in rpm subdir or where ever rpmbuild got it from
+SPEC_PATH=${RPM_SOURCE_DIR:-rpm}/${RPM_PACKAGE_NAME:-dsme}.spec
+SPEC_VERS=$(grep '^Version:' $SPEC_PATH |sed -e 's/^.*:[[:space:]]*//')
+
+if [ "$SPEC_VERS" != "$AC_VERS" ]; then
+  echo >&2 "$AC_PATH=$AC_VERS vs $SPEC_PATH=$SPEC_VERS"
+
+  # When building untagged commits via obs the spec will have as
+  # a version something like  "<previous_tag>+<branch>.<hash>".
+  # Accept those, if version matches up to the first '+'.
+  if [ "${SPEC_VERS%%+*}" = "$AC_VERS" ]; then
+    echo >&2 "  (ignored - assuming $AC_VERS + work in progress)"
+  else
+    RES=1
+  fi
 fi
 
-# The yaml file is included in the git tree, but not in the tarball
-# that is used during the OBS package build ...
+# The yaml file is included in the git tree, but might not be available
+# when making package build via OBS ...
+YAML_PATH=${RPM_SOURCE_DIR:-rpm}/${RPM_PACKAGE_NAME:-dsme}.yaml
+
 if [ -f $YAML_PATH ]; then
   YAML_VERS=$(grep '^Version:' $YAML_PATH |sed -e 's/^.*:[[:space:]]*//')
-  if [ "$RPM_VERS" != "$YAML_VERS" ]; then
-    echo >&2 "$YAML_PATH $YAML_VERS vs $RPM_PATH $RPM_VERS"
+  if [ "$YAML_VERS" != "$AC_VERS" ]; then
+    echo >&2 "$AC_PATH=$AC_VERS vs $YAML_PATH=$YAML_VERS"
     RES=1
   fi
 fi
@@ -31,4 +41,5 @@ if [ $RES != 0 ]; then
   echo >&2 "Conflicting package versions"
 fi
 
+# Stop the rpm-build ifthere were conflicts
 exit $RES


### PR DESCRIPTION
Consider "0.62.13+devel.681.6.g2230479" = "0.62.13" to ease
making test builds in the OBS.
