### PR TITLE
Fix 64-bit compilation issues

### DIFF
--- a/test/dummy_bme.c
+++ b/test/dummy_bme.c
@@ -232,7 +232,7 @@ int bme_extmsg_handler(int client)
     tBMEmsgGeneric *gm = msgp;
 
     if ((n = read(client, buf, sizeof(buf))) < sizeof(*gm)) {
-	bme_log(LOG_DEBUG, "got %d bytes instead of %d from client's fd %d (possible disconnect)\n",
+	bme_log(LOG_DEBUG, "got %d bytes instead of %zd from client's fd %d (possible disconnect)\n",
 				n, sizeof(*gm), client);
 	return -1;
     }


### PR DESCRIPTION
Substitute raw integer to/from pointer casts with glib macros
GPOINTER_TO_INT and GINT_TO_POINTER.

Modify sort_comparator() to be fully qualified GCompareFunc
that returns negative/zero/positive instead of just 0/1.

Fix possible numeric overflow in msg_comparator().

Fix printf-style format string in dummy_bme test utility.
