### PR TITLE
Change ControlGroupAttribute to set ControlGroup only

### DIFF
--- a/rpm/dsme.service
+++ b/rpm/dsme.service
@@ -9,7 +9,7 @@ Type=notify
 # When starting dsme gets initial runlevel from the bootstate file
 # If it doesn't exist, we default to USER
 # This works because EnvironmentFile overrides Environment
-ControlGroupAttribute=cpu.rt_runtime_us 800000
+ControlGroup=cpu:/
 Environment=BOOTSTATE=USER
 EnvironmentFile=-/run/systemd/boot-status/bootstate
 ExecStart=/usr/sbin/dsme -p /usr/lib/dsme/libstartup.so --systemd


### PR DESCRIPTION
This overrides the default logic for dsme service, and places all its processes back in the root cgroup of the "cpu" hierarchy, which has the full RT budget assigned.
