### PR TITLE
Do not close /dev/alarm before the final rtc wakeup programming

### DIFF
--- a/modules/iphb.c
+++ b/modules/iphb.c
@@ -2576,9 +2576,6 @@ cleanup:
 /** Shutdown */
 void module_fini(void)
 {
-    /* close android alarm device */
-    android_alarm_quit();
-
     /* cancel timers */
     rtc_cancel_finetune();
     clientlist_cancel_wakeup_timeout();
@@ -2589,6 +2586,9 @@ void module_fini(void)
     /* set wakeup alarm before closing the rtc */
     rtc_set_alarm_powerup();
     rtc_detach();
+
+    /* close android alarm device */
+    android_alarm_quit();
 
     /* cleanup rest of what is in the epoll set */
     listenfd_quit();


### PR DESCRIPTION
Both /dev/alarm and /dev/rtc should be reprogrammed on dsme exit.

If /dev/alarm is closed before that, the we might end up using
the previously programmed actual alarm time instead of the one
minute before we want.
