### PR TITLE
[iphb] Prefer CLOCK_BOOTTIME over CLOCK_MONOTONIC 

### DIFF
--- a/modules/iphb.c
+++ b/modules/iphb.c
@@ -223,8 +223,15 @@ static bool monotime_get_tv(struct timeval *tv)
 
     struct timespec ts;
 
+#if defined(CLOCK_BOOTTIME)
+    if( clock_gettime(CLOCK_BOOTTIME, &ts) < 0 ) {
+        if( clock_gettime(CLOCK_MONOTONIC, &ts) < 0 )
+            timerclear(tv);
+    }
+#else
     if( clock_gettime(CLOCK_MONOTONIC, &ts) < 0 )
 	timerclear(tv);
+#endif
     else {
 	TIMESPEC_TO_TIMEVAL(tv, &ts);
 	res = true;


### PR DESCRIPTION
The CLOCK_MONOTONIC might get frozen during suspend. CLOCK_BOOTTIME does not have this problem and should be used when available.

ANDROID_ALARM_ELAPSED_REALTIME is unreliable/non-monotonic, do not use it.
