### PR TITLE
Added more info to bootlogger JB#14632 

### DIFF
--- a/modules/bootreasonlogger.c
+++ b/modules/bootreasonlogger.c
@@ -224,8 +224,8 @@ static void log_startup(void)
     if (system_still_booting())
         write_log("Startup: ", get_powerup_reason_str());
     else {
-        /* System has already booted. Why we are here?
-         * Most likely dsme daemon has been restarted
+        /* System has already booted. We are here because
+         * dsme daemon has been restarted
          */
         write_log("Startup: ", "dsme daemon restarted, not real system startup");
     }


### PR DESCRIPTION
New entries in /var/log/systemboot.log look like this
20140129_132249 Received: shutdown request from pid 897: /usr/sbin/mce
20140129_132250 Received: dsme internal state SHUTDOWN
20140129_132254 Shutdown: User Power Key
20140129_132317 Startup:  pwr_on_status=pwr_on_by_USB
20140129_132318 Received: dsme internal state ACTDEAD
20140129_150651 Shutdown: Reason Unknown
20140129_150652 Startup:  dsme daemon restarted, not real system startup
20140129_150652 Received: dsme internal state USER
20140130_095634 Shutdown: SW update reboot
20140130_095701 Startup:  pwr_on_status=pwr_on_by_SW_reboot
20140130_095702 Received: dsme internal state USER
