### PR TITLE
Changes in thermal state messaging require libdsme >= 0.62.0

### DIFF
--- a/rpm/dsme.spec
+++ b/rpm/dsme.spec
@@ -31,7 +31,7 @@ BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(dbus-glib-1)
 BuildRequires:  pkgconfig(libiphb)
-BuildRequires:  pkgconfig(dsme)
+BuildRequires:  pkgconfig(dsme) >= 0.62.0
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  pkgconfig(mce) >= 1.12.3
 BuildRequires:  python

--- a/rpm/dsme.yaml
+++ b/rpm/dsme.yaml
@@ -28,7 +28,7 @@ PkgConfigBR:
     - dbus-1
     - dbus-glib-1
     - libiphb
-    - dsme
+    - dsme >= 0.62.0
     - systemd
     - mce >= 1.12.3
 


### PR DESCRIPTION
The DSM_MSGTYPE_SET_THERMAL_STATE message was replaced with
DSM_MSGTYPE_SET_THERMAL_STATUS and building dsme requires
having libdsme >= 0.62.0 installed.
