### PR TITLE
Add error handling to glib io watches

### DIFF
--- a/dsme/mainloop.c
+++ b/dsme/mainloop.c
@@ -74,7 +74,8 @@ static bool set_up_signal_pipe(void)
     if (!(chan = g_io_channel_unix_new(signal_pipe[0]))) {
         goto close_and_fail;
     }
-    watch = g_io_add_watch(chan, G_IO_IN, handle_signal, 0);
+    watch = g_io_add_watch(chan, G_IO_IN | G_IO_ERR | G_IO_HUP | G_IO_NVAL,
+			   handle_signal, 0);
     g_io_channel_unref(chan);
     if (!watch) {
         goto close_and_fail;

--- a/modules/heartbeat.c
+++ b/modules/heartbeat.c
@@ -42,9 +42,9 @@ static gboolean emit_heartbeat_message(GIOChannel*  source,
                                        gpointer     data)
 {
     // handle errors
-    if (condition & (G_IO_ERR | G_IO_HUP)) {
+    if (condition & (G_IO_ERR | G_IO_HUP | G_IO_NVAL)) {
         // the wd process has probably died; remove the watch & quit
-        dsme_log(LOG_DEBUG, "heartbeat: I/O error or HUP");
+        dsme_log(LOG_CRIT, "heartbeat: I/O error or HUP, terminating");
         dsme_main_loop_quit(EXIT_FAILURE);
         return false;
     }
@@ -89,7 +89,7 @@ static bool start_heartbeat(void)
         goto fail;
     }
     if (!(watch = g_io_add_watch(chan,
-                                 (G_IO_IN | G_IO_ERR | G_IO_HUP),
+                                 G_IO_IN | G_IO_ERR | G_IO_HUP | G_IO_NVAL,
                                  emit_heartbeat_message,
                                  0)))
     {

--- a/modules/pwrkeymonitor.c
+++ b/modules/pwrkeymonitor.c
@@ -420,7 +420,9 @@ probe_evdev_device(const char *path)
     }
     g_io_channel_set_buffered(chan, false);
 
-    if( !(watch = g_io_add_watch(chan, G_IO_IN, process_kbevent, 0)) )
+    if( !(watch = g_io_add_watch(chan,
+				 G_IO_IN | G_IO_ERR | G_IO_HUP | G_IO_NVAL,
+				 process_kbevent, 0)) )
     {
         dsme_log(LOG_ERR, PFIX"%s: unable to add io channel watch", path);
         goto EXIT;

--- a/modules/thermalsensor_battery.c
+++ b/modules/thermalsensor_battery.c
@@ -181,7 +181,7 @@ static void connect_bme()
 
       if (!(chan = g_io_channel_unix_new(request_fd)) ||
           !g_io_add_watch(chan,
-                          (G_IO_IN | G_IO_ERR | G_IO_HUP),
+                          G_IO_IN | G_IO_ERR | G_IO_HUP | G_IO_NVAL,
                           handle_battery_temperature_response,
                           0))
       {
@@ -252,7 +252,7 @@ static gboolean handle_battery_temperature_response(GIOChannel*  source,
           got_status = false;
       }
   }
-  if (condition & (G_IO_ERR | G_IO_HUP)) {
+  if (condition & (G_IO_ERR | G_IO_HUP | G_IO_NVAL)) {
       dsme_log(LOG_DEBUG, "bme connection ERR or HUP");
       keep_connection = false;
   }


### PR DESCRIPTION
Make sure every g_io_add_watch() call requests also error conditions
and fix callbacks so that realized error conditions do not leave the
io watch active and thus generate a virtual busyloop.

[dsme] Add error handling to glib io watches. Fixes JB#17046
