### PR TITLE
[systemd] Limit dsme restarts to two per 10 mins. JB#18248

### DIFF
--- a/rpm/dsme.service
+++ b/rpm/dsme.service
@@ -17,6 +17,9 @@ EnvironmentFile=-/var/lib/environment/dsme/*.conf
 ExecStart=/usr/sbin/dsme -p /usr/lib/dsme/libstartup.so --systemd
 Restart=always
 RestartSec=1
+StartLimitInterval=600
+StartLimitBurst=2
+StartLimitAction=reboot
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We had problem that dsme was restarted every two minutes. Current systemd default values for restarts are 3 times in 3 minutes thus dsme never hit the limit and phone was forever in limbo state.
These new values limit max 2 dsme restarts in 10 minutes and if that limit is reached, whole system will reboot.

Signed-off-by: Pekka Lundstrom pekka.lundstrom@jollamobile.com
