### PR TITLE
Remove obsoleted ControlGroup from service file

### DIFF
--- a/rpm/dsme.service
+++ b/rpm/dsme.service
@@ -7,7 +7,6 @@ Conflicts=shutdown.target
 
 [Service]
 Type=notify
-ControlGroup=cpu:/
 # When starting dsme gets initial runlevel from the bootstate file
 # If it doesn't exist, we default to USER
 # This works because EnvironmentFile overrides Environment


### PR DESCRIPTION
Systemd 208 does not support ControlGroup in service file anymore.
