### PR TITLE
Increase StartLimitBurst from 2 to 3

### DIFF
--- a/rpm/dsme.service
+++ b/rpm/dsme.service
@@ -17,7 +17,7 @@ ExecStart=/usr/sbin/dsme -p /usr/lib/dsme/libstartup.so --systemd
 Restart=always
 RestartSec=1
 StartLimitInterval=600
-StartLimitBurst=2
+StartLimitBurst=3
 StartLimitAction=reboot
 
 [Install]


### PR DESCRIPTION
It might be that 2 is too small because also manual restarts
are counted to failed service. Let's increase value by one so
that we don't get any problems during system update.

Signed-off-by: Matti Kosola matti.kosola@jollamobile.com
