### PR TITLE
Dont allow ACTDEAD to USER change on low battery

### DIFF
--- a/modules/state.c
+++ b/modules/state.c
@@ -91,7 +91,7 @@
  * switch from ACTDEAD to USER
  * TODO: don't hard code this but support config value
  */
-#define DSME_MINIMUM_BATTERY_TO_USER    5
+#define DSME_MINIMUM_BATTERY_TO_USER    3
 
 #define BATTERY_LEVEL_PATH   "/run/state/namespaces/Battery/ChargePercentage"
 
@@ -1130,7 +1130,7 @@ static int  get_battery_level(void)
     }
     if (!ok) {
         dsme_log(LOG_ERR, "state: FAILED to read %s", BATTERY_LEVEL_PATH);
-        batterylevel = 66; /* return fake value, don't block state change */
+        batterylevel = DSME_MINIMUM_BATTERY_TO_USER; /* return fake, don't block state change */
     }
     return batterylevel;
 }


### PR DESCRIPTION
If battery level is too low we should not allow state change from ACTDEAD to USER because phone will anyhow shutdown as soon as we get into USER state.
Shutdown and bootup takes lots of power so now the minimum level is defined as high as 5. Later we can support configurable levels. Now we go with hard-coded level, but what would be correct level? Is 5 too high?

Signed-off-by: Pekka Lundstrom pekka.lundstrom@jollamobile.com
