### PR TITLE
[build] Add usb-moded requirement

### DIFF
--- a/rpm/dsme.spec
+++ b/rpm/dsme.spec
@@ -11,6 +11,7 @@ Source2:    dsme-rpmlintrc
 Requires:   systemd
 Requires:   statefs
 Requires:   ngfd
+Requires:   usb-moded
 Requires(preun): systemd
 Requires(post): systemd
 Requires(postun): systemd


### PR DESCRIPTION
The usbtracker module depends on usb-moded
