### PR TITLE
Make command line reboot go through dsme when applicable

### DIFF
--- a/reboot-via-dsme.sh
+++ b/reboot-via-dsme.sh
@@ -1,0 +1,71 @@
+# Normally shutdown and reboot should always go through DSME.
+#
+# Running reboot/poweroff/etc binaries directly bypasses DSME
+# and the shutdown does not work the same way as powering off
+# via UI. The differences include for example:
+# - Emergency calls/alarms/charger/etc are not considered
+# - Applications do not get save-data and pre-shutdown signals
+# - Shutdown vibration, led and logo do not get triggered
+#
+# Use shell functions to allow users to continue using familiar
+# commands from interactive shell, but do the shutdown/reboot
+# via dsme.
+#
+# If needed, the real systemd binaries (e.g. reboot) can still
+# be invoked by using the full path:
+# # /usr/sbin/reboot
+#
+# Or by ignoring the shell functions via command:
+# # command reboot
+
+# Define shell functions for interactive shells only
+case "$-" in *i*) ;; *) return ;; esac
+
+# Replace simple poweroff/halt/reboot/shutdown invocations
+# with equivalent dsmetool operations
+
+poweroff()
+{
+  [ "$#" -eq 0 ] && /usr/sbin/dsmetool --shutdown || /usr/sbin/poweroff "$@"
+}
+halt()
+{
+  [ "$#" -eq 0 ] && /usr/sbin/dsmetool --shutdown || /usr/sbin/halt "$@"
+}
+reboot()
+{
+  [ "$#" -eq 0 ] && /usr/sbin/dsmetool --reboot   || /usr/sbin/reboot "$@"
+}
+shutdown()
+{
+  DSME_SHUTDOWN_MODE="--shutdown"
+  DSME_SHUTDOWN_TIME=""
+  DSME_SHUTDOWN_MESG=""
+  DSME_SHUTDOWN_UNKN=""
+  for f in "$@"; do
+    case "$f" in
+      -H|--halt|-P|--poweroff|-h)
+        DSME_SHUTDOWN_MODE="--shutdown"
+        ;;
+      -r|--reboot)
+        DSME_SHUTDOWN_MODE="--reboot"
+        ;;
+      -*)
+        DSME_SHUTDOWN_UNKN="y"
+        ;;
+      *)
+        if [ -z "$DSME_SHUTDOWN_TIME" ]; then
+          DSME_SHUTDOWN_TIME="$f"
+        else
+          DSME_SHUTDOWN_MESG="$f"
+        fi
+        ;;
+   esac
+  done
+  [ "${DSME_SHUTDOWN_TIME:-now}" = "now" ] && \
+  [ "$DSME_SHUTDOWN_MESG" = "" ] && \
+  [ "$DSME_SHUTDOWN_UNKN" = "" ] && \
+  /usr/sbin/dsmetool "$DSME_SHUTDOWN_MODE" || /usr/sbin/shutdown "$@"
+  unset DSME_SHUTDOWN_MODE DSME_SHUTDOWN_TIME
+  unset DSME_SHUTDOWN_MESG DSME_SHUTDOWN_UNKN
+}

--- a/rpm/dsme.spec
+++ b/rpm/dsme.spec
@@ -66,6 +66,7 @@ make %{?_smp_mflags}
 rm -rf %{buildroot}
 %make_install
 
+install -D -m 644 reboot-via-dsme.sh %{buildroot}/etc/profile.d/reboot-via-dsme.sh
 install -D -m 644 %{SOURCE1} %{buildroot}/lib/systemd/system/%{name}.service
 install -d %{buildroot}/lib/systemd/system/multi-user.target.wants/
 ln -s ../%{name}.service %{buildroot}/lib/systemd/system/multi-user.target.wants/%{name}.service
@@ -97,6 +98,8 @@ systemctl daemon-reload || :
 /lib/systemd/system/multi-user.target.wants/%{name}.service
 /var/lib/dsme
 %config(noreplace) /var/lib/dsme/alarm_queue_status
+%dir /etc/profile.d
+/etc/profile.d/reboot-via-dsme.sh
 
 %files tests
 %defattr(-,root,root,-)


### PR DESCRIPTION
Users that are not deeply familiar with nemomobile can assume that
running reboot utility from command line is just fine for rebooting
the device. Most of the times it does work, but it also bypasses
shutdown/reboot policy that is in dsme (emergency calls etc should
block immediate reboot/shutdown) and causes save-data and pre-shutdown
signals not to be sent / shutdown logo not shown.

Simply replacing reboot, halt and poweroff utilities with other binaries
is problematic since it would a) require non-upstreamable patches to
systemd b) cause failures if dsme itself is down for some reason.

Add aliases that make reboot, halt and poweroff attempt to do shutdown
via dsme 1st and if that fails continue with systemd helper binary.
This way reboot etc entered from interactive shell do their job via dsme.